### PR TITLE
Update dbt project name to match repo name

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -2,7 +2,7 @@
 # Name your project! Project names should contain only lowercase characters
 # and underscores. A good project name should reflect your organization's
 # name or the intended use of these models
-name: 'analytics'
+name: 'platform'
 version: '1.0.0'
 config-version: 2
 


### PR DESCRIPTION
This upstream dbt project should have a consistent name...
1. The repository name is `c24-workshops-platform`.
2. The dbt project `name` should also be `platform`.