### PR TITLE
Make snapshot schema take from the environment

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -62,4 +62,4 @@ seeds:
         rate: NUMBER
 
 snapshots:
-  +target_schema: snapshots_dev
+  +target_schema: "{{ target.schema }}"


### PR DESCRIPTION
Snapshot schemas are fixed to `snapshots_dev` - thus every users snapshot will go into the same schema - not good for workshop.

We have made the "schema" on the env be unique by using the attendees name https://dbt-labs.slack.com/archives/C07GUQ8LKFX/p1727720112764019

So we'll want snapshots to take that schema too instead of hard coded to `snapshots_dev`.